### PR TITLE
Use custom char rendering

### DIFF
--- a/lib/command_builder.dart
+++ b/lib/command_builder.dart
@@ -124,9 +124,6 @@ class CmdBuilder {
           final g = _byteBuffer[1];
           final b = _byteBuffer[2];
           
-          debugPrint(
-              "COLOR CMD: Received RGB bytes: 0x${r.toRadixString(16).padLeft(2, '0').toUpperCase()} ($r), 0x${g.toRadixString(16).padLeft(2, '0').toUpperCase()} ($g), 0x${b.toRadixString(16).padLeft(2, '0').toUpperCase()} ($b)");
-          
           final cmd = ColourCmd(r: r, g: g, b: b);
           _commandStreamController.add(cmd);
           _reset();

--- a/lib/main_screen.dart
+++ b/lib/main_screen.dart
@@ -41,6 +41,8 @@ class _MainScreenState extends State<MainScreen> {
             _grid.setChar((x: cmd.x, y: cmd.y), cmd.char, cmd.invert);
             break;
           case ClearCmd():
+            // Clear command also sets the background color
+            _grid.setBackground(cmd.r, cmd.g, cmd.b);
             _grid.clear();
             break;
           case ColourCmd():

--- a/lib/widgets/screen_char_row.dart
+++ b/lib/widgets/screen_char_row.dart
@@ -90,11 +90,16 @@ class ScreenCharRow extends StatelessWidget {
       mainAxisSize: MainAxisSize.min,
       children: rowChars.map((cell) {
         final isInvertedSpaceChar = cell.char == " " && cell.invert;
-        final backgroundColor = isInvertedSpaceChar
-            ? cell.color
+        
+        // For inverted space characters, use the cell's color as background
+        // For regular characters, use the grid's background unless inverted
+        final backgroundColor = isInvertedSpaceChar 
+            ? cell.color 
             : (cell.invert ? cell.color : grid.background);
-        final textColor = isInvertedSpaceChar
-            ? cell.color
+            
+        // Text color is the inverse of the background when inverted
+        final textColor = isInvertedSpaceChar 
+            ? cell.color 
             : (cell.invert ? grid.background : cell.color);
         
         return CustomPaint(


### PR DESCRIPTION
Using custom rendering removes gap artifacts between char grid cells.

Also fix setting background colour correctly.